### PR TITLE
fix: pin redhat-actions on commit sha to prevent ci/cd poisoning

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Buildah Action
-      uses: redhat-actions/buildah-build@v2
+      uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056
       with:
         image: ghcr.io/${{ github.repository }}
         tags: ${{ github.sha }}


### PR DESCRIPTION
Pinned redhat sha to its current commit redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056